### PR TITLE
Added an alernate way to pass inputs to Sql.q

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ Better is a prepared statement, or stored procedure.
 ##### Params:
 ```javascript
 (query : String, inputs : [ { name : 'param1', type : Sql.driver.TYPE, value : 'My Value' }, ... ], optionalCallback)
+or
+(query : String, inputs : { myParam1 : 'My Value', paramNumba2 : 'This val', ... }, optionalCallback)
 ```
 
 ```javascript

--- a/mssql.js
+++ b/mssql.js
@@ -27,10 +27,17 @@ function sqlQuery (query, inputs, cb) {
 
     var request = new sql.Request(Sql.connection);
     if (inputs) {
-      _.each(inputs, function (e) {
-        if (e.type) request.input(e.name, e.type, e.value);
-        else        request.input(e.name, e.value);
-      });
+      if (_.isArray(inputs)) {
+        _.each(inputs, function (e) {
+          if (e.type) request.input(e.name, e.type, e.value);
+          else        request.input(e.name, e.value);
+        });
+      }
+      else if (_.isObject(inputs)) {
+        _.each(inputs, function (e, k) {
+          request.input(k, e);
+        });
+      }
     }
 
     request.query(query, cb);

--- a/package.js
+++ b/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name: "emgee:mssql",
   summary: "mssql wrapper: non-reactive SQL Server package",
-  version: "1.3.0_5",
+  version: "1.3.0_6",
   git: "https://github.com/emgee3/meteor-mssql.git",
   documentation: "README.md"
 });


### PR DESCRIPTION
This will provide an alternative, more intuitive way to pass inputs:

``` javascript
Sql.q(
  "SELECT * FROM MyTable WHERE first_name = LIKE @firstname + '%' AND last_name LIKE @lastname + '%'",
  { firstname : "Alfred", lastname: "Hitchcock" }
);
```

instead of the current (and sometimes annoying):

``` javascript
Sql.q("SELECT * FROM MyTable WHERE first_name = LIKE @firstname + '%' AND last_name LIKE @lastname + '%'", [
    {name : "firstname", value : "Alfred"},
    {name : "lastname", value : "Hitchcock"}
]);

or

Sql.q("SELECT * FROM MyTable WHERE first_name = LIKE @firstname + '%' AND last_name LIKE @lastname + '%'", [
    {name : "firstname", type : Sql.driver.NVARCHAR, value : "Alfred"},
    {name : "lastname", type : Sql.driver.NVARCHAR, value : "Hitchcock"}
]);
```

The old method remains valid and is useful where SQL types should be specified in the inputs.
